### PR TITLE
trims whitespace from user input

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         event.preventDefault()
 
         $('form p').show()
-        var name = $("#github_username").val()
+        var name = $("#github_username").val().trim()
 
         get_github_id_for(name, function(username, id) {
           add_twitter_link_for(username, id)


### PR DESCRIPTION
Trims leading and trailing whitespace from user input in case users (like me :) input some accidentally, thereby yielding the below:

<img width="678" src="https://user-images.githubusercontent.com/788678/52607057-d94e0900-2e42-11e9-9103-8103d5f7be9a.png">
